### PR TITLE
Fix for packages pointing to a repo

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function(options, allDone) {
 	};
 
 	var isUpdateAvailable = function(component) {
-		if (component.update.target === component.update.latest) return false;
+		if (!component.update || component.update.target === component.update.latest) return false;
 		if (options.interactive) {
 			console.log(component.pkgMeta.name + ': ' +  chalk.red(component.update.target) + ' → ' + chalk.green(component.update.latest));
 			var answer = readlineSync.question('Upgrade now? (y/N)').toLowerCase();


### PR DESCRIPTION
When a package points on a repo in bower.json (in my case, a branch name on a repo), bower-update crashes with:

```
/usr/lib/node_modules/bower-update/index.js:56
        if (component.update.target === component.update.latest) return false;
                            ^
TypeError: Cannot read property 'target' of undefined
```

This patch fixes it (there are no updates to look for on a branch).
