### PR TITLE
Allow saving of updated dependencies to bower.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,7 @@ npm install -g bower-update
 Just `cd` to your project’s root folder (where your `bower.json` is located) and run:
 
 ```
-bower-update [--non-interactive]
+bower-update [--non-interactive] [--save]
 ```
 
 ### Options
@@ -27,6 +27,10 @@ bower-update [--non-interactive]
 #### non-interactive
 
 bower-update will not ask you before updating any components.
+
+#### save
+
+Updated dependencies will be stored to `bower.json`.
 
 
 ## Changelog

--- a/bin/bower-update
+++ b/bin/bower-update
@@ -26,6 +26,12 @@ var opts = nomnom
 		flag: true,
 		help: 'Ask before updating every component.'
 	})
+	.option('save', {
+		abbr: 'S',
+		flag: true,
+		default: false,
+		help: 'Store updated dependencies to bower.json'
+	})
 	.parse();
 
 
@@ -40,7 +46,8 @@ function showVersion() {
 function main() {
 	updater({
 		cwd: process.cwd(),
-		interactive: !opts.interactive
+		interactive: !opts.interactive,
+		save: !!opts.save
 	}, function (err, updated) {
 		if (err) {
 			console.log(chalk.red.underline(err));

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "bower": "~1.4.0",
+    "bower-json": "^0.4.0",
     "chalk": "~1.0.0",
     "lodash": "~3.6.0",
     "nomnom": "~1.8.1",


### PR DESCRIPTION
Fixes #11
Updated dependencies are stored to `bower.json` when the `--save` or `-S` flags are passed. I used the (official) `bower-json` module for finding and reading the bower.json files, since they provide a fallback mechanism out-of-the-box: bower.json > component.json > .bower.json
